### PR TITLE
Ticket1797 momentum slit updates

### DIFF
--- a/barndoorsApp/Db/momentum_slits.db
+++ b/barndoorsApp/Db/momentum_slits.db
@@ -7,12 +7,12 @@
 #    LOW_GAP_LIMIT lowest gap value that can be set
 #
 
-record(motor,"$(P)MOMENTUMSLITS") 
+record(motor,"$(P)MSLITS") 
 { 
 	field(DESC, "Gap on the momentum slits")
     field(DTYP,"Soft Channel") 
-    field(OUT,"$(P)convertGapToDrive.A  PP MS") 
-    field(RDBL,"$(P)convertDriveToGap.VAL  NPP MS") 
+    field(OUT,"$(P)MFRMGAP.A  PP MS") 
+    field(RDBL,"$(P)MTOGAP.VAL  NPP MS") 
     field(URIP,"Yes") 
     field(STOO,"$(P)$(MTR).STOP  PP MS") 
     field(DINP,"$(P)$(MTR).DMOV  NPP MS") 
@@ -29,22 +29,20 @@ record(motor,"$(P)MOMENTUMSLITS")
 	info(alarm,"Motors")
 }
 
-alias("$(P)MOMENTUMSLITS", "$(P):MOMENTUMSLITS:SP")
-alias("$(P)MOMENTUMSLITS", "$(P):MOMENTUMSLITS:SP:RBV")
+alias("$(P)MSLITS", "$(P)MSLITS:SP")
+alias("$(P)MSLITS", "$(P)MSLITS:SP:RBV")
 
 
-record(calcout, "$(P)convertGapToDrive") 
+record(calcout, "$(P)MFRMGAP") 
 { 
-	
 	field(DESC,"Convert gap distance to drive voltage") 
     field(CALC,"A / 2.0") 	
     field(OUT,"$(P)$(MTR).DVAL  PP MS")
 }
 
-record(calcout,"$(P)convertDriveToGap") 
+record(calcout,"$(P)MTOGAP") 
 {
     field(DESC,"Convert drive voltage to gap distance")
-     
     field(INPA,"$(P)$(MTR).DRBV  CP MS")
     field(CALC,"A * 2.0") 
 }

--- a/settings/README
+++ b/settings/README
@@ -4,5 +4,5 @@ README
 The calibration files for the barndoors are held in the common calibrations folder. They should be in 
 C:/Instrument/Settings/config/common/barndoors.
 
-The barndoors and empty jaws file should be copied to  C:\Instrument\Settings\config\<machine>\configurations\galil as 
+The galil1. barndoors and empty jaws file should be copied to  C:\Instrument\Settings\config\<machine>\configurations\galil as 
 needed on the isntrument.

--- a/settings/README
+++ b/settings/README
@@ -4,5 +4,5 @@ README
 The calibration files for the barndoors are held in the common calibrations folder. They should be in 
 C:/Instrument/Settings/config/common/barndoors.
 
-The galil1. barndoors and empty jaws file should be copied to  C:\Instrument\Settings\config\<machine>\configurations\galil as 
-needed on the isntrument.
+The galil1, barndoors and empty jaws file should be copied to  C:\Instrument\Settings\config\<machine>\configurations\galil as 
+needed on the instrument.

--- a/settings/galil1.cmd
+++ b/settings/galil1.cmd
@@ -1,0 +1,32 @@
+## configure galil crate 1
+
+## passed parameters
+##   GCID - galil crate software index. Numbering starts at 0 - will always be 0 if there is one to one galil crate <-> galil IOC mapping  
+##   GALILADDR01 - address of this galil
+
+## see README_galil_cmd.txt for usage of commands below
+
+#G21X3Config($(GCID),"$(GALILADDR01)",8,2100,2000) 
+GalilCreateController("Galil", "$(GALILADDR01)", 20)
+ 
+#G21X3NameConfig($(GCID),"A",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"B",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"C",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"D",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"E",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"F",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"G",0,0,0,0,0,0,"",0,0,"",1,0)
+#G21X3NameConfig($(GCID),"H",0,0,0,0,0,0,"",0,0,"",1,0)
+GalilCreateAxis("Galil","A",0,"",1)
+GalilCreateAxis("Galil","B",0,"",1)
+GalilCreateAxis("Galil","C",0,"",1)
+GalilCreateAxis("Galil","D",0,"",1)
+GalilCreateAxis("Galil","E",0,"",1)
+GalilCreateAxis("Galil","F",0,"",1)
+GalilCreateAxis("Galil","G",0,"",1)
+GalilCreateAxis("Galil","H",0,"",1)
+
+#G21X3StartCard($(GCID),"$(GALIL)/db/galil_Default_Header.gmc;$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc!$(GALIL)/db/galil_Piezo_Home.gmc;$(GALIL)/db/galil_Default_Footer.gmc",0,0)
+
+# The Galil controller is started with just the code for controlling the slits
+GalilStartController("Galil","$(GALIL)/gmc/galil_Muon_Slits.gmc",0,0,3)


### PR DESCRIPTION
This relates to issue https://github.com/ISISComputingGroup/IBEX/issues/1797

No test is required for the galil1 - this is merely an example file.

For the db file, rebuild this module, run a galil with the barndoors setup in place (simulate the galil), the PVs should be named as below, and in the case of the `:SP` and `:SP:RBV` without any double `::` entries